### PR TITLE
use SGX device plugin by default

### DIFF
--- a/example-sgx-manual-mount.yaml
+++ b/example-sgx-manual-mount.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  selector:
+    matchLabels:
+      run: hello-world
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: hello-world
+    spec:
+      containers:
+      - name: hello-world
+        image: $IMAGE
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: GREETING
+          value: howdy!
+        volumeMounts:
+        - mountPath: /dev/sgx
+          name: dev-sgx
+        securityContext:
+          privileged: true
+      volumes:
+      - name: dev-sgx
+        hostPath:
+          path: /dev/sgx


### PR DESCRIPTION
use the SGX device plugin for Kubernetes by default, so the user does
not need to care about different device names or driver implementations.
the device plugin also allow for unprivileged containers.

although we assume the SGX device plugin is installed, the documentation
also includes instructions on how to provision the device manually
through hostPath volumes.

also, a couple of minor improvements:

* update public cas address to scone-cas.cf;
* updated app outputs to match the current version;
* updated app entrypoints to match current base image (python->python3);
* updated demo script to accept IMAGEREPO and use it throughout the
execution;
* remove references to a particular driver implementation (/dev/isgx);
* skipped port 8081 when port-forwarding, since CAS is most likely to be
listening there.