### PR TITLE
update registry reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd $(mktemp -d)
 We use the following base image:
 
 ```bash
-export BASE_IMAGE=sconecuratedimages/apps:python-3.7.3-alpine3.10
+export BASE_IMAGE=sconecuratedimages/kubernetes:python-3.7.3-alpine3.10-scone4.2
 ```
 
 Have fun!
@@ -249,7 +249,7 @@ spec:
       hostNetwork: true
       containers:
         - name: local-attestation
-          image: sconecuratedimages/services:las
+          image: sconecuratedimages/kubernetes:las-scone4.2
           resources:
             limits:
               sgx.k8s.io/sgx: 1

--- a/run_hello_world.sh
+++ b/run_hello_world.sh
@@ -27,11 +27,11 @@ Copyright (C) 2017-2020 scontain.com
 export IMAGEREPO=${IMAGEREPO:-sconecuratedimages/kubernetes}
 
 # modify if needed
-export SCONE_CAS_ADDR=4-0-0.scone-cas.cf
-export SCONE_CAS_IMAGE="sconecuratedimages/services:cas-scone4.0"
+export SCONE_CAS_ADDR=4-2-1.scone-cas.cf
+export SCONE_CAS_IMAGE="registry.scontain.com:5050/sconecuratedimages/services:cas-scone4.2.1"
 #export CAS_MRENCLAVE=`(docker pull $SCONE_CAS_IMAGE > /dev/null ; docker run -i --rm -e "SCONE_HASH=1" $SCONE_CAS_IMAGE cas) || echo 9a1553cd86fd3358fb4f5ac1c60eb8283185f6ae0e63de38f907dbaab7696794`  # compute MRENCLAVE for current CAS
-export CAS_MRENCLAVE=460e24c965a94fd3718cb22472926c9517fb2912d2c8ca97ea26228e14d0bbdd
-export BASE_IMAGE=sconecuratedimages/apps:python-3.7.3-alpine3.10
+export CAS_MRENCLAVE=4cd0fe54d3d8d787553b7dac7347012682c402220acd062e4d0da3bbe10a1c2c
+export BASE_IMAGE=sconecuratedimages/kubernetes:python-3.7.3-alpine3.10-scone4.2
 export NAMESPACE=hello-scone-$RANDOM
 set -e
 
@@ -267,7 +267,7 @@ spec:
       hostNetwork: true
       containers:
         - name: local-attestation
-          image: sconecuratedimages/kubernetes:las
+          image: sconecuratedimages/kubernetes:las-scone4.2
           ports:
           - containerPort: 18766
             hostPort: 18766


### PR DESCRIPTION
remove references to repositories that no longer exist due to the
migration to the new Scontain registry [1]. please note that every image on the tutorial
is still hosted at Docker hub (`kubernetes` repo), apart from the CAS
image on `run_hello_world.sh` (L31).

additionally, pin all versions to SCONE 4.2.1.

[1] https://sconedocs.github.io/registry/